### PR TITLE
🔧 [cli] fix rollup compatible with Windows

### DIFF
--- a/cli/rollup/common/common.ts
+++ b/cli/rollup/common/common.ts
@@ -7,6 +7,8 @@
  * 江湖的业务千篇一律，复杂的代码好几百行。
  */
 import typescript from '@rollup/plugin-typescript';
+import * as url from 'url';
+import { pathToFileURL } from 'url';
 
 export const commonConfig = {
   plugins: [typescript()]
@@ -14,4 +16,19 @@ export const commonConfig = {
 
 export const resolvePath = (path: string) => {
   return path;
+}
+/**
+ * @see  {@link https://blog.logrocket.com/alternatives-dirname-node-js-es-modules/ __dirname}
+ * @returns same `import.meta.url`
+ */
+export const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+/**
+ * @see  {@link https://github.com/nodejs/node/issues/31710 url}
+ * @param targetPath 
+ * @returns `file:///c:/x/y/z`
+ */
+export const importAbs = async (targetPath: string) => {
+  const fileUrl = pathToFileURL(targetPath).href;
+  return await import(fileUrl);
 }

--- a/cli/rollup/config/tools/jsx/shuimo.build.config.ts
+++ b/cli/rollup/config/tools/jsx/shuimo.build.config.ts
@@ -10,12 +10,14 @@
 import { ShuimoBuildConfig } from '../../../index';
 import path from 'path';
 
+import {  __dirname } from '../../../common/common';
+
 export const config: ShuimoBuildConfig = {
   plugins: {
     // resolve: true,
     // commonjs: true,
     typescript: {
-      filterRoot: path.resolve(__dirname,'../../../../../tools/jsx'),
+      filterRoot: path.resolve(__dirname, '../../../tools/jsx'),
       exclude: ['**/vue/**', '**/react/**', '**/apps/**']
     }
   }

--- a/cli/rollup/script/build.ts
+++ b/cli/rollup/script/build.ts
@@ -6,13 +6,13 @@
  *
  * 江湖的业务千篇一律，复杂的代码好几百行。
  */
-
 import * as path from 'path';
 import { OutputOptions, rollup } from 'rollup';
 import { resolvePackage } from './resolvePackage';
 import console from 'console';
 import { resolveRollupConfig } from './resolveRollupConfig';
 import fs from 'fs';
+import { importAbs } from 'common/common';
 
 const pathJoin = (args: Array<string | undefined>) => args.filter(e => e !== undefined).join(path.sep);
 
@@ -35,13 +35,12 @@ const target = getTarget();
 if (!target) {console.warn('you should provide target');}
 
 const pkgDir = path.resolve(pathJoin(['../../', target]));
-const packageJson = require(pathJoin([pkgDir, 'package.json']));
-
+const packagePath = pathJoin([pkgDir, 'package.json']);
 
 const run = async () => {
   let bundle;
   let buildField = false;
-  const pkgOption = resolvePackage(pkgDir, packageJson);
+  const pkgOption = resolvePackage(pkgDir, await importAbs(packagePath));
   const rollupConfig = await resolveRollupConfig(pkgDir, target!);
   if (!pkgOption.output) {return;}
   try {
@@ -58,6 +57,7 @@ const run = async () => {
     console.error(e);
     buildField = true;
   }
+
 
   if (bundle) {
     const outputOptionList: OutputOptions[] = Array.isArray(pkgOption.output) ? pkgOption.output : [pkgOption.output];

--- a/cli/rollup/script/resolveRollupConfig.ts
+++ b/cli/rollup/script/resolveRollupConfig.ts
@@ -10,7 +10,7 @@ import { RequiredShuimoBuildConfig, ShuimoBuildConfig } from '../index';
 import fs from 'fs';
 import path from 'path';
 import { RollupOptions } from 'rollup';
-
+import { importAbs, __dirname } from '../common/common';
 import rollupResolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import commonjs from '@rollup/plugin-commonjs';
@@ -51,15 +51,12 @@ export const resolveRollupConfig = async (pkgDir: string, target: string) => {
   };
 
   const url = path.resolve(pathJoin(['.', 'config', target, 'shuimo.build.config.ts']));
-
   if (fs.existsSync(url)) {
-    let { config: userConfig } = await import(url) as { config: ShuimoBuildConfig };
+    let { config: userConfig } = await importAbs(url) as { config: ShuimoBuildConfig };
     config = mergeConfig(config, userConfig);
   }
-
   const { resolve, commonjs: c, postcss: p, typescript: t } = config.plugins!;
   const { filterRoot, tsconfig } = config.plugins?.typescript!;
-
   const rollupConfig: RollupOptions = {
     plugins: [
       resolve ? rollupResolve() : undefined,


### PR DESCRIPTION
🔧 : fix the problem of build:postcss  under Windows
🔧 : fix the problem of build:jsx  under Windows